### PR TITLE
use binmode to keep CRLF correctly

### DIFF
--- a/t/02_multipart_form_data.t
+++ b/t/02_multipart_form_data.t
@@ -66,6 +66,7 @@ sub slurp {
     my $fname = shift;
     open my $fh, '<', $fname
         or Carp::croak("Can't open '$fname' for reading: '$!'");
+    binmode $fh;
     scalar(do { local $/; <$fh> })
 }
 


### PR DESCRIPTION
binmode is required to keep CRLF under Win32.
