### PR TITLE
Bug fixes and constructor changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl extension HTTP-Body-Builder
 
 {{$NEXT}}
 
+    - Only the first key/value pair passed to ->add_content ended up in the
+      body with the UrlEncoded module. Fixed by Dave Rolsky.
+
 0.03 2013-10-08T23:32:29Z
 
     - use binmode to keep CRLF correctly

--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ Revision history for Perl extension HTTP-Body-Builder
     - Only the first key/value pair passed to ->add_content ended up in the
       body with the UrlEncoded module. Fixed by Dave Rolsky.
 
+    - Allow the constructors to accept content (and files, for MultiPart)
+      parameters. Implemented by Dave Rolsky.
+
 0.03 2013-10-08T23:32:29Z
 
     - use binmode to keep CRLF correctly

--- a/lib/HTTP/Body/Builder/MultiPart.pm
+++ b/lib/HTTP/Body/Builder/MultiPart.pm
@@ -108,7 +108,7 @@ HTTP::Body::Builder::MultiPart - multipart/form-data
     use HTTP::Body::Builder::MultiPart;
 
     my $builder = HTTP::Body::Builder::MultiPart->new();
-    $builder->add('x' => 'y');
+    $builder->add_content('x' => 'y');
     $builder->as_string;
     # => x=y
 

--- a/lib/HTTP/Body/Builder/UrlEncoded.pm
+++ b/lib/HTTP/Body/Builder/UrlEncoded.pm
@@ -17,7 +17,7 @@ sub new {
 
 sub add_content {
     my ($self, $name, $value) = @_;
-    push @{$self->{content}}, [$name, $value];
+    push @{$self->{content}}, $name, $value;
 }
 
 sub content_type {
@@ -33,7 +33,7 @@ sub as_string {
     my ($self) = @_;
 
     my $uri = URI->new('http:');
-    $uri->query_form(@{$self->{content}});
+    $uri->query_form($self->{content});
     my $content = $uri->query;
 
     # HTML/4.01 says that line breaks are represented as "CR LF" pairs (i.e., `%0D%0A')

--- a/lib/HTTP/Body/Builder/UrlEncoded.pm
+++ b/lib/HTTP/Body/Builder/UrlEncoded.pm
@@ -53,7 +53,7 @@ HTTP::Body::Builder::UrlEncoded - C<application/x-www-encoded>
     use HTTP::Body::Builder::UrlEncoded;
 
     my $builder = HTTP::Body::Builder::UrlEncoded->new();
-    $builder->add('x' => 'y');
+    $builder->add_content('x' => 'y');
     $builder->as_string;
     # => x=y
 

--- a/lib/HTTP/Body/Builder/UrlEncoded.pm
+++ b/lib/HTTP/Body/Builder/UrlEncoded.pm
@@ -10,9 +10,18 @@ use URI;
 sub new {
     my $class = shift;
     my %args = @_==1 ? %{$_[0]} : @_;
-    bless {
+    my $content = delete $args{content};
+    my $self = bless {
         %args
     }, $class;
+    if ($content) {
+        for my $key (keys %{$content}) {
+            for my $value (ref $content->{$key} ? @{$content->{$key}} : $content->{$key}) {
+                $self->add_content($key => $value);
+            }
+        }
+    }
+    return $self;
 }
 
 sub add_content {
@@ -52,7 +61,7 @@ HTTP::Body::Builder::UrlEncoded - C<application/x-www-encoded>
 
     use HTTP::Body::Builder::UrlEncoded;
 
-    my $builder = HTTP::Body::Builder::UrlEncoded->new();
+    my $builder = HTTP::Body::Builder::UrlEncoded->new(content => {'foo' => 42});
     $builder->add_content('x' => 'y');
     $builder->as_string;
     # => x=y
@@ -61,9 +70,27 @@ HTTP::Body::Builder::UrlEncoded - C<application/x-www-encoded>
 
 =over 4
 
-=item my $builder = HTTP::Body::Builder::UrlEncoded->new()
+=item my $builder = HTTP::Body::Builder::UrlEncoded->new(...)
 
-Create new instance of HTTP::Body::Builder::UrlEncoded.
+Create a new HTTP::Body::Builder::UrlEncoded instance.
+
+The constructor accepts named arguments as a hash. The only allowed parameter
+is C<content>. This parameter should be a hashref.
+
+Each key/value pair in this hashref will be added to the builder by calling
+the C<add_content> method.
+
+If the value of one of the content hashref's keys is an arrayref, then each
+member of the arrayref will be added separately.
+
+    HTTP::Body::Builder::UrlEncoded->new(content => {'a' => 42, 'b' => [1, 2]});
+
+is equivalent to the following:
+
+    my $builder = HTTP::Body::Builder::UrlEncoded->new;
+    $builder->add_content('a' => 42);
+    $builder->add_content('b' => 1);
+    $builder->add_content('b' => 2);
 
 =item $builder->add_content($key => $value);
 

--- a/t/01_www_form.t
+++ b/t/01_www_form.t
@@ -26,5 +26,18 @@ subtest 'file' => sub {
     ok $@;
 };
 
+subtest 'constructor' => sub {
+    my $builder = HTTP::Body::Builder::UrlEncoded->new(
+        content => {'foo' => 42, 'bar' => 'hello', 'baz' => [ 1, 2 ]});
+    $builder->add_content('x' => 'y');
+    # We need to use like instead of looking at the whole string because we
+    # just use keys to iterate of the hash passed to the constructor.
+    like $builder->as_string, qr/foo=42/;
+    like $builder->as_string, qr/bar=hello/;
+    like $builder->as_string, qr/baz=1/;
+    like $builder->as_string, qr/baz=2/;
+    like $builder->as_string, qr/x=y/;
+};
+
 done_testing;
 

--- a/t/01_www_form.t
+++ b/t/01_www_form.t
@@ -8,7 +8,8 @@ use HTTP::Body::Builder::UrlEncoded;
 subtest 'simple' => sub {
     my $builder = HTTP::Body::Builder::UrlEncoded->new();
     $builder->add_content('x' => 'y');
-    is $builder->as_string, 'x=y';
+    $builder->add_content('foo' => 'bar');
+    is $builder->as_string, 'x=y&foo=bar';
 };
 
 subtest 'binary' => sub {

--- a/t/02_multipart_form_data.t
+++ b/t/02_multipart_form_data.t
@@ -20,6 +20,23 @@ subtest 'simple' => sub {
     );
 };
 
+subtest 'multiple content k/v pairs' => sub {
+    my $builder = HTTP::Body::Builder::MultiPart->new;
+    $builder->add_content(x => 'y');
+    $builder->add_content(foo => 'bar');
+    is $builder->as_string, join ('',
+        "--xYzZY$CRLF",
+        qq{Content-Disposition: form-data; name="x"$CRLF},
+        "$CRLF",
+        "y$CRLF",
+        "--xYzZY$CRLF",
+        qq{Content-Disposition: form-data; name="foo"$CRLF},
+        "$CRLF",
+        "bar$CRLF",
+        "--xYzZY--$CRLF",
+    );
+};
+
 subtest 'simple case with file' => sub {
     my $builder = HTTP::Body::Builder::MultiPart->new;
     $builder->add_content(x => "y\0z");

--- a/t/02_multipart_form_data.t
+++ b/t/02_multipart_form_data.t
@@ -97,6 +97,25 @@ subtest 'write_file' => sub {
     );
 };
 
+subtest 'constructor' => sub {
+    my $builder = HTTP::Body::Builder::MultiPart->new(
+        content => {x => 'y'},
+        files   => {z => 't/dat/foo'},
+    );
+    is $builder->as_string, join('',
+        "--xYzZY$CRLF",
+        qq{Content-Disposition: form-data; name="x"$CRLF},
+        "$CRLF",
+        "y$CRLF",
+        "--xYzZY$CRLF",
+        qq{Content-Disposition: form-data; name="z"; filename="foo"$CRLF},
+        "Content-Type: text/plain$CRLF",
+        "$CRLF",
+        "foofoofoo$CRLF",
+        "--xYzZY--$CRLF",
+    );
+};
+
 done_testing;
 
 sub slurp {

--- a/t/02_multipart_form_data.t
+++ b/t/02_multipart_form_data.t
@@ -56,6 +56,26 @@ subtest 'simple case with file' => sub {
     );
 };
 
+subtest 'multiple files' => sub {
+    my $builder = HTTP::Body::Builder::MultiPart->new;
+    $builder->add_file(x => 't/dat/foo');
+    $builder->add_file(y => 't/dat/bar');
+    is $builder->content_type, 'multipart/form-data';
+    is $builder->as_string, join('',
+        "--xYzZY$CRLF",
+        qq{Content-Disposition: form-data; name="x"; filename="foo"$CRLF},
+        "Content-Type: text/plain$CRLF",
+        "$CRLF",
+        "foofoofoo$CRLF",
+        "--xYzZY$CRLF",
+        qq{Content-Disposition: form-data; name="y"; filename="bar"$CRLF},
+        "Content-Type: text/plain$CRLF",
+        "$CRLF",
+        "barbarbar$CRLF",
+        "--xYzZY--$CRLF",
+    );
+};
+
 subtest 'write_file' => sub {
     my $builder = HTTP::Body::Builder::MultiPart->new;
     $builder->add_content(x => "y\0z");

--- a/t/dat/bar
+++ b/t/dat/bar
@@ -1,0 +1,1 @@
+barbarbar


### PR DESCRIPTION
This PR contains the following changes:
- Fixed the SYNOPSIS for both modules, which showed an `add` method that doesn't exist.
- The UrlEncoded module was broken, and only included the first k/v pair in the body.
- Added tests for multiple content pairs and fails for MultiPart (which worked, but was not tested).
- Allow the constructors to accept named `content` and `files` parameters.
